### PR TITLE
fix issue #5

### DIFF
--- a/doerffelbot/main.py
+++ b/doerffelbot/main.py
@@ -9,6 +9,7 @@ import CONFIG as conf
 
 
 TOKEN = conf.TOKEN  # Token of @doerffelbot
+my_chat_id = conf.my_chat_id  # my own telegram-'chat id'
 
 # init updater: handle incoming messages
 updater = Updater(token=TOKEN)

--- a/doerffelbot/main.py
+++ b/doerffelbot/main.py
@@ -9,8 +9,6 @@ import CONFIG as conf
 
 
 TOKEN = conf.TOKEN  # Token of @doerffelbot
-old_TOKEN = conf.old_TOKEN  # Token of @johannstodobot
-my_chat_id = conf.my_chat_id  # my own telegram-'chat id'
 
 # init updater: handle incoming messages
 updater = Updater(token=TOKEN)


### PR DESCRIPTION
remove unnecessary lines
```python
old_TOKEN = conf.old_TOKEN  # Token of @johannstodobot
my_chat_id = conf.my_chat_id  # my own telegram-'chat id'
```
which were causing an error as `README.md` does not say you should
create a line `old_TOKEN` in `CONFIG.py`.
As far as I can see these lines are also unnecessary.