### PR TITLE
3 implement docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+.vscode/
+data/
+env/
+.gitignore
+CONFIG.py
+LICENSE
+Makefile
+README.md
+requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use an official Python runtime as a parent image
+FROM python:3.7-slim
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+# COPY ./doerffelbot /app
+# COPY .dockerignore /app
+# COPY docker-compose.yml /app
+# COPY Dockerfile /app
+# COPY req-docker.txt /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --trusted-host pypi.python.org -r req-docker.txt
+
+# Make port 80 available to the world outside this container
+EXPOSE 80
+
+# Define environment variable
+ENV NAME World
+
+# Run app.py when the container launches
+CMD ["python", "-m", "doerffelbot.main"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 run:
+	make run-docker
+
+run-docker:
+	docker-compose up
+
+run-python:
 	env/bin/python -m doerffelbot.main
 
 dep:

--- a/README.md
+++ b/README.md
@@ -2,16 +2,33 @@
 
 **Table of Content**
 - [About](#about)
-- [Getting started](#getting-started)
+- [Getting started: fast](#getting-started-fast)
+- [Getting started: full](#getting-started-full)
   - [CONFIG.py](#configpy)
   - [virtualenv](#virtualenv)
   - [going online](#going-online)
 
 ## About
-A telegram-bot to access the substitution plan of the Georg-Samuel-Dörffel-Gymnasium in Weida, Thuringia, Germany.
-The grammar school is cerified with the MINT-Dings.
+A telegram-bot to access the substitution plan of the Georg-Samuel-Dörffel-Gymnasium in Weida, Thuringia, Germany.  
+The grammar school is certified with the MINT-Dings.
 
-## Getting started
+## Getting started: fast
+The fasted way to get started is possible by cloning a public gist and pulling the latest image from docker-hub:
+
+```shell
+$ git clone git@gist.github.com:f48e23a765f094c3c399c6b6c1e9425f.git
+$ cd f48e23a765f094c3c399c6b6c1e9425f/
+$ make all
+```
+It runs for a moment and then it will open `init_CONFIG.py` in `vi`. You now have to fill in the credentials and exit with `:x`.
+
+It finishes with something like:
+
+```
+docker run --rm -v "/root/to/Doerffelbot-minimal/data:/app/data" -v "/root/to/Doerffelbot-minimal/CONFIG.py:/app/CONFIG.py" urhengulas/doerffelbot
+```
+
+## Getting started: full
 
 ### CONFIG.py
 First you have to create a `CONFIG.py` file, which contains the credentials of the bot and the substitution plan.  
@@ -30,9 +47,10 @@ my_chat_id = 123456789
 vplan = {"username": "xxxxx", "password": "xxxxx"}
 ```
 
-After filling in your data you can rename it to `CONFIG.py`.
+You need to fill in the actual credentials to use the bot.  
+After doing that you can rename it to `CONFIG.py`.
 
-`make setup` also creates a new directory `data/` and inide two files `ids.set` and `vertretung.pdf`.
+`make setup` also creates a new directory `data/` and inside two files `ids.set` and `vertretung.pdf`.
 
 ### virtualenv
 Next you have to install the required python packages:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@ services:
   dbot:
     build: .
     volumes:
-      - "./data:/data"
+      - "./data:/app/data"
       - "./CONFIG.py:/app/CONFIG.py"
     command: "python -m doerffelbot.main"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "0.2"
+services:
+  dbot:
+    build: .
+    volumes:
+      - "./data:/data"
+      - "./CONFIG.py:/app/CONFIG.py"
+    command: "python -m doerffelbot.main"

--- a/req-docker.txt
+++ b/req-docker.txt
@@ -1,0 +1,2 @@
+requests
+python-telegram-bot


### PR DESCRIPTION
# Description

This PR implements the usage of docker into the Doerffelbot. You can now run the bot via `docker-compose up`.  
Additionally, it is possible to run the bot with just the [docker image urhengulas/doerffelbot](https://cloud.docker.com/u/urhengulas/repository/docker/urhengulas/doerffelbot) and [this public gist](https://gist.github.com/Urhengulas/f48e23a765f094c3c399c6b6c1e9425f). Instrutions can be found in the README.

Fixes no issue.

# How Has This Been Tested?

- [x] docker-compose up
- [x] make python-run

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules